### PR TITLE
gsoc_responsibilities.md: Add CoC

### DIFF
--- a/community/gsoc_responsibilities.md
+++ b/community/gsoc_responsibilities.md
@@ -4,6 +4,9 @@ Responsibilities of coala’s GSoC Participants
 This Document hold the responsibilities we expect coala’s GSoC participants to
 fulfil.
 
+The coala's GSoC participants and mentors are also required to follow our 
+coala community's [Code of Conduct](https://coala.io/coc).
+
 
 Students
 --------


### PR DESCRIPTION
Adds CoC reference to be followed by GSoC participants and mentors.

Closes https://github.com/coala/teams/issues/75